### PR TITLE
Add multi-node playground support with topology visualization

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -1,4 +1,4 @@
-import {Columns2, LayoutPanelLeft, WifiOff} from 'lucide-react'
+import {Columns2, LayoutPanelLeft, Network, WifiOff} from 'lucide-react'
 import {useState} from 'react'
 import {useQuery} from '@tanstack/react-query'
 import {api} from './lib/api'
@@ -12,8 +12,9 @@ import {InteractPanel} from './panels/InteractPanel'
 import {PartySelector} from './panels/PartySelector'
 import {SplitView} from './panels/SplitView'
 import {Terminal} from './panels/Terminal'
+import {TopologyView} from './panels/TopologyView'
 
-type ViewMode = 'editor' | 'split'
+type ViewMode = 'editor' | 'split' | 'topology'
 
 export function App() {
   const files = useFiles()
@@ -70,6 +71,17 @@ export function App() {
             >
               <Columns2 className="h-3 w-3" />
               Multi-Party
+            </button>
+            <button
+              onClick={() => setViewMode('topology')}
+              className={`flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-medium transition ${
+                viewMode === 'topology'
+                  ? 'bg-zinc-700 text-zinc-200'
+                  : 'text-zinc-500 hover:text-zinc-300'
+              }`}
+            >
+              <Network className="h-3 w-3" />
+              Topology
             </button>
           </div>
 
@@ -140,7 +152,7 @@ export function App() {
               />
             </div>
           </>
-        ) : (
+        ) : viewMode === 'split' ? (
           /* Split View: Multi-Party */
           <div className="flex-1 flex flex-col overflow-hidden">
             <div className="flex-1 overflow-hidden">
@@ -149,6 +161,22 @@ export function App() {
                 templates={templates}
                 projectName={projectName}
               />
+            </div>
+            <div className="h-40 shrink-0 border-t border-zinc-800/50">
+              <Terminal
+                logs={build.logs}
+                building={build.building}
+                testing={build.testing}
+                onBuild={build.triggerBuild}
+                onTest={build.triggerTest}
+              />
+            </div>
+          </div>
+        ) : (
+          /* Topology View */
+          <div className="flex-1 flex flex-col overflow-hidden">
+            <div className="flex-1 overflow-hidden">
+              <TopologyView />
             </div>
             <div className="h-40 shrink-0 border-t border-zinc-800/50">
               <Terminal

--- a/playground/src/hooks/useTopology.ts
+++ b/playground/src/hooks/useTopology.ts
@@ -1,0 +1,24 @@
+import {useQuery} from '@tanstack/react-query'
+import {api} from '../lib/api'
+
+export function useTopology() {
+  const {data: topologyData} = useQuery({
+    queryKey: ['topology'],
+    queryFn: api.getTopology,
+    staleTime: 30000,
+  })
+
+  const {data: statusData, refetch} = useQuery({
+    queryKey: ['topology-status'],
+    queryFn: api.getTopologyStatus,
+    refetchInterval: 5000,
+  })
+
+  return {
+    mode: topologyData?.mode ?? 'single',
+    topology: topologyData?.topology ?? null,
+    synchronizer: topologyData?.synchronizer ?? null,
+    participants: statusData?.participants ?? [],
+    refetch,
+  }
+}

--- a/playground/src/lib/api.ts
+++ b/playground/src/lib/api.ts
@@ -93,6 +93,27 @@ export const api = {
   getMultiPartyContracts: (parties: string[]) =>
     request<{contracts: Record<string, ActiveContract[]>}>(`/api/contracts/multi?parties=${parties.join(',')}`),
 
+  getTopology: () => request<{
+    mode: 'single' | 'multi'
+    participants: Array<{name: string; port: number}>
+    synchronizer: {admin: number; publicApi: number} | null
+    topology: {
+      participants: Array<{name: string; parties: string[]; ports: {admin: number; jsonApi: number; ledgerApi: number}}>
+      synchronizer: {admin: number; publicApi: number}
+    } | null
+  }>('/api/topology'),
+
+  getTopologyStatus: () => request<{
+    participants: Array<{
+      name: string
+      healthy: boolean
+      version?: string
+      port: number
+      parties: Array<Record<string, unknown>>
+      contractCount: number
+    }>
+  }>('/api/topology/status'),
+
   build: () => request<{darPath?: string; durationMs?: number}>('/api/build', {method: 'POST'}),
 
   test: () => request<{passed: boolean; output: string}>('/api/test', {method: 'POST'}),

--- a/playground/src/panels/TopologyView.tsx
+++ b/playground/src/panels/TopologyView.tsx
@@ -1,0 +1,177 @@
+import {Activity, Box, FileText, Network, RefreshCw, Server, Users} from 'lucide-react'
+import {useTopology} from '../hooks/useTopology'
+
+export function TopologyView() {
+  const {mode, topology, participants, refetch} = useTopology()
+
+  return (
+    <div className="h-full flex flex-col bg-canton-950">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-2 border-b border-zinc-800/50 shrink-0">
+        <div className="flex items-center gap-2">
+          <Network className="h-4 w-4 text-canton-400" />
+          <span className="text-xs font-semibold text-zinc-300">Network Topology</span>
+          <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${
+            mode === 'multi'
+              ? 'bg-canton-600/20 text-canton-400'
+              : 'bg-zinc-800 text-zinc-500'
+          }`}>
+            {mode === 'multi' ? 'Multi-Node' : 'Single Node'}
+          </span>
+        </div>
+        <button onClick={() => refetch()} className="text-zinc-500 hover:text-zinc-300 transition">
+          <RefreshCw className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {/* Topology visualization */}
+      <div className="flex-1 overflow-auto p-6">
+        {/* Synchronizer */}
+        {topology?.synchronizer && (
+          <div className="flex justify-center mb-8">
+            <SynchronizerNode
+              admin={topology.synchronizer.admin}
+              publicApi={topology.synchronizer.publicApi}
+            />
+          </div>
+        )}
+
+        {/* Connection lines */}
+        {topology?.synchronizer && participants.length > 0 && (
+          <div className="flex justify-center mb-4">
+            <div className="w-px h-8 bg-zinc-700/50" />
+          </div>
+        )}
+
+        {/* Participant nodes */}
+        <div className="flex justify-center gap-6 flex-wrap">
+          {participants.map(participant => (
+            <ParticipantNode
+              key={participant.name}
+              name={participant.name}
+              healthy={participant.healthy}
+              version={participant.version}
+              port={participant.port}
+              parties={participant.parties}
+              contractCount={participant.contractCount}
+            />
+          ))}
+        </div>
+
+        {participants.length === 0 && (
+          <div className="text-center text-zinc-600 text-sm mt-8">
+            No participants detected. Start the sandbox or use --full for multi-node.
+          </div>
+        )}
+      </div>
+
+      {/* Stats footer */}
+      <div className="px-4 py-2 border-t border-zinc-800/50 flex gap-4 text-[10px] text-zinc-500 shrink-0">
+        <span className="flex items-center gap-1">
+          <Server className="h-3 w-3" />
+          {participants.length} participant{participants.length !== 1 ? 's' : ''}
+        </span>
+        <span className="flex items-center gap-1">
+          <Activity className="h-3 w-3" />
+          {participants.filter(p => p.healthy).length} healthy
+        </span>
+        <span className="flex items-center gap-1">
+          <Users className="h-3 w-3" />
+          {participants.reduce((sum, p) => sum + p.parties.length, 0)} parties
+        </span>
+        <span className="flex items-center gap-1">
+          <FileText className="h-3 w-3" />
+          {participants.reduce((sum, p) => sum + p.contractCount, 0)} contracts
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ── Synchronizer Node ────────────────────────────────────────────────
+
+function SynchronizerNode({admin, publicApi}: {admin: number; publicApi: number}) {
+  return (
+    <div className="rounded-xl border border-canton-600/30 bg-canton-950/80 backdrop-blur p-4 w-64 text-center">
+      <div className="flex items-center justify-center gap-2 mb-2">
+        <Network className="h-4 w-4 text-canton-400" />
+        <span className="text-sm font-semibold text-canton-300">Synchronizer</span>
+      </div>
+      <div className="space-y-1 text-[10px] text-zinc-500">
+        <div>Admin: <span className="text-zinc-400 font-mono">:{admin}</span></div>
+        <div>Public API: <span className="text-zinc-400 font-mono">:{publicApi}</span></div>
+      </div>
+    </div>
+  )
+}
+
+// ── Participant Node ─────────────────────────────────────────────────
+
+function ParticipantNode({name, healthy, version, port, parties, contractCount}: {
+  name: string
+  healthy: boolean
+  version?: string
+  port: number
+  parties: Array<Record<string, unknown>>
+  contractCount: number
+}) {
+  return (
+    <div className={`rounded-xl border backdrop-blur p-4 w-64 ${
+      healthy
+        ? 'border-emerald-600/30 bg-zinc-900/80'
+        : 'border-red-600/30 bg-zinc-900/80'
+    }`}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <Box className={`h-4 w-4 ${healthy ? 'text-emerald-400' : 'text-red-400'}`} />
+          <span className="text-sm font-semibold text-zinc-200">{name}</span>
+        </div>
+        <div className={`h-2 w-2 rounded-full ${
+          healthy ? 'bg-emerald-400 shadow shadow-emerald-400/50' : 'bg-red-400 shadow shadow-red-400/50'
+        }`} />
+      </div>
+
+      {/* Version + Port */}
+      <div className="space-y-1 text-[10px] mb-3">
+        <div className="flex justify-between text-zinc-500">
+          <span>Version</span>
+          <span className="text-zinc-400 font-mono">{version ?? 'unknown'}</span>
+        </div>
+        <div className="flex justify-between text-zinc-500">
+          <span>JSON API</span>
+          <span className="text-zinc-400 font-mono">:{port}</span>
+        </div>
+        <div className="flex justify-between text-zinc-500">
+          <span>Contracts</span>
+          <span className="text-zinc-400 font-mono">{contractCount}</span>
+        </div>
+      </div>
+
+      {/* Parties */}
+      {parties.length > 0 && (
+        <div className="border-t border-zinc-800/50 pt-2">
+          <div className="text-[9px] text-zinc-600 uppercase tracking-wider mb-1.5">Parties</div>
+          <div className="space-y-1">
+            {parties.map((party, i) => {
+              const id = String(party.party ?? party.identifier ?? '')
+              const displayName = String(party.displayName ?? id.split('::')[0] ?? `party-${i}`)
+              return (
+                <div key={id || i} className="flex items-center gap-1.5 text-[10px]">
+                  <Users className="h-3 w-3 text-canton-400/60" />
+                  <span className="text-zinc-300">{displayName}</span>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {parties.length === 0 && (
+        <div className="text-[10px] text-zinc-600 text-center pt-2 border-t border-zinc-800/50">
+          No parties
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/commands/playground.ts
+++ b/src/commands/playground.ts
@@ -26,7 +26,9 @@ import {fileURLToPath} from 'node:url'
 import {createBuilder} from '../lib/builder.js'
 import {loadConfig} from '../lib/config.js'
 import {createDamlSdk} from '../lib/daml.js'
+import {createFullDevServer, type FullDevServer} from '../lib/dev-server-full.js'
 import {createDevServer} from '../lib/dev-server.js'
+import {createDockerManager} from '../lib/docker.js'
 import {CantonctlError, ErrorCode} from '../lib/errors.js'
 import {createSandboxToken} from '../lib/jwt.js'
 import {createLedgerClient} from '../lib/ledger-client.js'
@@ -63,14 +65,27 @@ export default class Playground extends Command {
 
   static override examples = [
     '<%= config.bin %> playground',
+    '<%= config.bin %> playground --full',
     '<%= config.bin %> playground --port 8080',
     '<%= config.bin %> playground --no-open',
   ]
 
   static override flags = {
+    'base-port': Flags.integer({
+      default: 10_000,
+      description: 'Base port for multi-node topology (--full mode only)',
+    }),
+    'canton-image': Flags.string({
+      default: 'ghcr.io/digital-asset/decentralized-canton-sync/docker/canton:0.5.3',
+      description: 'Canton Docker image (--full mode only)',
+    }),
+    full: Flags.boolean({
+      default: false,
+      description: 'Start multi-node Docker topology instead of single sandbox',
+    }),
     'json-api-port': Flags.integer({
       default: 7575,
-      description: 'Canton JSON Ledger API port',
+      description: 'Canton JSON Ledger API port (single sandbox mode)',
     }),
     'no-open': Flags.boolean({
       default: false,
@@ -87,7 +102,7 @@ export default class Playground extends Command {
     }),
     'sandbox-port': Flags.integer({
       default: 5001,
-      description: 'Canton sandbox port',
+      description: 'Canton sandbox port (single sandbox mode)',
     }),
   }
 
@@ -114,9 +129,46 @@ export default class Playground extends Command {
     const sdk = createDamlSdk({runner})
     const ledgerUrl = `http://localhost:${flags['json-api-port']}`
 
-    // Start sandbox if needed
+    // Start sandbox or multi-node topology
     let devServer: Awaited<ReturnType<typeof createDevServer>> | null = null
-    if (!flags['no-sandbox']) {
+    let fullDevServer: FullDevServer | null = null
+
+    const findDarFile = async (dir: string) => {
+      try {
+        const entries = await fs.promises.readdir(dir)
+        const dar = entries.find(e => e.endsWith('.dar'))
+        return dar ? path.join(dir, dar) : null
+      } catch { return null }
+    }
+
+    if (!flags['no-sandbox'] && flags.full) {
+      out.log('')
+      out.info('Starting multi-node Canton topology via Docker...')
+
+      const docker = createDockerManager({output: out, runner})
+      fullDevServer = createFullDevServer({
+        build: async (pd: string): Promise<void> => { await sdk.build({projectDir: pd}) },
+        cantonImage: flags['canton-image'],
+        config,
+        createClient: createLedgerClient,
+        createToken: createSandboxToken,
+        docker,
+        findDarFile,
+        mkdir: async (dir: string): Promise<void> => { await fs.promises.mkdir(dir, {recursive: true}) },
+        output: out,
+        readFile: (p) => fs.promises.readFile(p),
+        rmdir: (dir) => fs.promises.rm(dir, {force: true, recursive: true}),
+        watch: (paths, opts) => watch(paths, opts),
+        writeFile: (p, content) => fs.promises.writeFile(p, content, 'utf8'),
+      })
+
+      await fullDevServer.start({
+        basePort: flags['base-port'],
+        projectDir,
+      })
+
+      out.success('Multi-node topology ready')
+    } else if (!flags['no-sandbox']) {
       out.log('')
       out.info('Starting Canton sandbox...')
 
@@ -124,13 +176,7 @@ export default class Playground extends Command {
         config,
         createClient: createLedgerClient,
         createToken: createSandboxToken,
-        findDarFile: async (dir: string) => {
-          try {
-            const entries = await fs.promises.readdir(dir)
-            const dar = entries.find(e => e.endsWith('.dar'))
-            return dar ? path.join(dir, dar) : null
-          } catch { return null }
-        },
+        findDarFile,
         isPortInUse,
         output: out,
         readFile: (p) => fs.promises.readFile(p),
@@ -210,6 +256,7 @@ export default class Playground extends Command {
         out.info('Shutting down...')
         await server.stop()
         if (devServer) await devServer.stop()
+        if (fullDevServer) await fullDevServer.stop()
         resolve()
       }
 

--- a/src/lib/serve.ts
+++ b/src/lib/serve.ts
@@ -30,6 +30,7 @@ import {WebSocketServer, type WebSocket} from 'ws'
 
 import type {Builder} from './builder.js'
 import {parseDamlSource, type DamlTemplate} from './daml-parser.js'
+import {detectTopology} from './topology.js'
 import type {OutputWriter} from './output.js'
 import type {TestRunner} from './test-runner.js'
 
@@ -160,7 +161,32 @@ export function createServeServer(deps: ServeServerDeps): ServeServer {
         readAs: ['Alice', 'Bob'],
       })
 
-      const client = createLedgerClient({baseUrl: ledgerUrl, token})
+      // Detect multi-node topology
+      const topology = await detectTopology(projectDir)
+      const isMultiNode = topology !== null && topology.participants.length > 0
+
+      // Create ledger clients — one per participant in multi-node, or single
+      const participantClients: Array<{client: LedgerClientLike; name: string; port: number}> = []
+
+      if (isMultiNode) {
+        for (const participant of topology!.participants) {
+          const baseUrl = `http://localhost:${participant.ports.jsonApi}`
+          participantClients.push({
+            client: createLedgerClient({baseUrl, token}),
+            name: participant.name,
+            port: participant.ports.jsonApi,
+          })
+        }
+      } else {
+        participantClients.push({
+          client: createLedgerClient({baseUrl: ledgerUrl, token}),
+          name: 'sandbox',
+          port: Number.parseInt(new URL(ledgerUrl).port, 10) || 7575,
+        })
+      }
+
+      // Default client (first participant or single sandbox)
+      const client = participantClients[0].client
 
       // Express app
       const app = express()
@@ -168,6 +194,70 @@ export function createServeServer(deps: ServeServerDeps): ServeServer {
       app.use(express.json())
 
       // ── REST API ────────────────────────────────────────────────
+
+      // ── Topology ─────────────────────────────────────────────
+
+      app.get('/api/topology', async (_req: Request, res: Response) => {
+        res.json({
+          mode: isMultiNode ? 'multi' : 'single',
+          participants: participantClients.map(pc => ({name: pc.name, port: pc.port})),
+          synchronizer: isMultiNode ? topology!.synchronizer : null,
+          topology: isMultiNode ? {
+            participants: topology!.participants.map(p => ({
+              name: p.name,
+              parties: p.parties,
+              ports: p.ports,
+            })),
+            synchronizer: topology!.synchronizer,
+          } : null,
+        })
+      })
+
+      app.get('/api/topology/status', async (_req: Request, res: Response) => {
+        const statuses = await Promise.all(
+          participantClients.map(async (pc) => {
+            let healthy = false
+            let version: string | undefined
+            let parties: Array<Record<string, unknown>> = []
+            let contractCount = 0
+
+            try {
+              const v = await pc.client.getVersion()
+              healthy = true
+              version = v.version as string
+            } catch { /* unhealthy */ }
+
+            if (healthy) {
+              try {
+                const p = await pc.client.getParties()
+                parties = p.partyDetails
+              } catch { /* no parties */ }
+
+              // Count contracts for each party
+              for (const party of parties) {
+                try {
+                  const partyId = String(party.party ?? party.identifier ?? '')
+                  if (partyId) {
+                    const contracts = await pc.client.getActiveContracts({filter: {party: partyId}})
+                    contractCount += contracts.activeContracts.length
+                  }
+                } catch { /* skip */ }
+              }
+            }
+
+            return {
+              contractCount,
+              healthy,
+              name: pc.name,
+              parties,
+              port: pc.port,
+              version,
+            }
+          }),
+        )
+
+        res.json({participants: statuses})
+      })
 
       // Read daml.yaml for project metadata (package name for template IDs)
       app.get('/api/project', async (_req: Request, res: Response) => {
@@ -247,13 +337,16 @@ export function createServeServer(deps: ServeServerDeps): ServeServer {
                   durationMs: result.durationMs,
                   type: result.cached ? 'build:cached' : 'build:success',
                 })
-                // Auto-upload DAR to sandbox after successful build
+                // Auto-upload DAR to ALL participants after successful build
                 if (result.darPath && !result.cached) {
-                  try {
-                    const darBytes = await fs.promises.readFile(result.darPath)
-                    await client.uploadDar(new Uint8Array(darBytes))
-                    broadcast({type: 'dar:uploaded', dar: result.darPath})
-                  } catch (uploadErr) { output.warn(`DAR upload failed: ${uploadErr}`) }
+                  const darBytes = await fs.promises.readFile(result.darPath)
+                  for (const pc of participantClients) {
+                    try {
+                      await pc.client.uploadDar(new Uint8Array(darBytes))
+                    } catch (uploadErr) { output.warn(`DAR upload to ${pc.name} failed: ${uploadErr}`) }
+                  }
+
+                  broadcast({type: 'dar:uploaded', dar: result.darPath, participants: participantClients.map(pc => pc.name)})
                 }
               } catch (err) {
                 broadcast({output: String(err), type: 'build:error'})
@@ -387,13 +480,16 @@ export function createServeServer(deps: ServeServerDeps): ServeServer {
         try {
           const result = await builder.build({force: true, projectDir})
           broadcast({dar: result.darPath, durationMs: result.durationMs, type: 'build:success'})
-          // Auto-upload DAR to sandbox
+          // Auto-upload DAR to ALL participants
           if (result.darPath) {
-            try {
-              const darBytes = await fs.promises.readFile(result.darPath)
-              await client.uploadDar(new Uint8Array(darBytes))
-              broadcast({type: 'dar:uploaded', dar: result.darPath})
-            } catch (uploadErr) { output.warn(`DAR upload failed: ${uploadErr}`) }
+            const darBytes = await fs.promises.readFile(result.darPath)
+            for (const pc of participantClients) {
+              try {
+                await pc.client.uploadDar(new Uint8Array(darBytes))
+              } catch (uploadErr) { output.warn(`DAR upload to ${pc.name} failed: ${uploadErr}`) }
+            }
+
+            broadcast({type: 'dar:uploaded', dar: result.darPath, participants: participantClients.map(pc => pc.name)})
           }
 
           res.json(result)


### PR DESCRIPTION
## Summary

Adds --full flag to cantonctl playground for multi-node Docker topology, plus a live network topology visualization.

### Multi-Node Backend
- Serve server detects topology via detectTopology(), creates LedgerClient per participant
- DAR auto-upload goes to ALL participants after build
- GET /api/topology returns mode + participant list + synchronizer
- GET /api/topology/status returns per-participant health, version, parties, contract count

### Playground --full Flag
- --full starts createFullDevServer (Docker multi-node)
- --base-port and --canton-image flags for customization
- Graceful shutdown handles Docker containers

### Topology View (Frontend)
- Third view mode: Editor / Multi-Party / Topology
- Synchronizer node card with ports
- Participant node cards: health dot, version, JSON API port, contract count, party list
- Stats footer: participant count, healthy count, party count, contract count
- Auto-refresh every 5 seconds

## Browser Verified (Multi-Node Docker)
- participant1: v3.4.8, :10013, 1 contract (after creating Token)
- participant2: v3.4.8, :10023, 0 contracts (Canton privacy)
- Synchronizer displayed with connection lines
- "Multi-Node" badge, live contract count updates
- Build successful, DAR uploaded to both participants

## Tests
490 total: 399 unit + 66 SDK + 9 sandbox + 2 Docker + 14 playground. All pass.
Full local CI green.