### PR TITLE
Fix Codex review: gate multi-node on runtime flag, parse synchronizer ports

### DIFF
--- a/src/commands/playground.ts
+++ b/src/commands/playground.ts
@@ -227,6 +227,7 @@ export default class Playground extends Command {
 
     await server.start({
       ledgerUrl,
+      multiNode: flags.full,
       port: flags.port,
       projectDir,
       staticDir,

--- a/src/lib/serve.ts
+++ b/src/lib/serve.ts
@@ -63,7 +63,7 @@ export interface ServeEvent {
 }
 
 export interface ServeServer {
-  start(opts: {port: number; projectDir: string; ledgerUrl: string; staticDir?: string}): Promise<void>
+  start(opts: {port: number; projectDir: string; ledgerUrl: string; staticDir?: string; multiNode?: boolean}): Promise<void>
   stop(): Promise<void>
   broadcast(event: ServeEvent): void
 }
@@ -161,9 +161,10 @@ export function createServeServer(deps: ServeServerDeps): ServeServer {
         readAs: ['Alice', 'Bob'],
       })
 
-      // Detect multi-node topology
-      const topology = await detectTopology(projectDir)
-      const isMultiNode = topology !== null && topology.participants.length > 0
+      // Use explicit multiNode flag to avoid binding to stale .cantonctl/ artifacts
+      // from a previous --full run. Only detect topology when explicitly requested.
+      const topology = opts.multiNode ? await detectTopology(projectDir) : null
+      const isMultiNode = opts.multiNode === true && topology !== null && topology.participants.length > 0
 
       // Create ledger clients — one per participant in multi-node, or single
       const participantClients: Array<{client: LedgerClientLike; name: string; port: number}> = []

--- a/src/lib/topology.ts
+++ b/src/lib/topology.ts
@@ -397,12 +397,27 @@ export async function detectTopology(projectDir: string): Promise<GeneratedTopol
       ports: {admin: 0, jsonApi: Number.parseInt(m[1], 10), ledgerApi: 0},
     }))
 
+    // Parse synchronizer ports from docker-compose port mappings
+    // Format: "HOST:CONTAINER" lines under ports: section
+    // The lowest port range is the synchronizer (basePort+1 admin, basePort+2 publicApi)
+    let syncAdmin = 0
+    let syncPublicApi = 0
+    const allPortMappings = [...composeContent.matchAll(/"(\d+):(\d+)"/g)]
+    if (allPortMappings.length > 0) {
+      const hostPorts = allPortMappings.map(m => Number.parseInt(m[1], 10)).sort((a, b) => a - b)
+      // Synchronizer ports are the two lowest (basePort+1 admin, basePort+2 publicApi)
+      if (hostPorts.length >= 2) {
+        syncAdmin = hostPorts[0]
+        syncPublicApi = hostPorts[1]
+      }
+    }
+
     return {
       bootstrapScript: '',
       cantonConf: '',
       dockerCompose: composeContent,
       participants,
-      synchronizer: {admin: 0, publicApi: 0},
+      synchronizer: {admin: syncAdmin, publicApi: syncPublicApi},
     }
   } catch {
     return null


### PR DESCRIPTION
Addresses Codex review comments from PR #3:

1. **Gate multi-node on runtime flag** - serve.ts now only calls detectTopology() when `opts.multiNode` is explicitly true. Prevents binding to stale .cantonctl/ artifacts from interrupted --full runs.

2. **Parse real synchronizer ports** - detectTopology() now extracts synchronizer admin/publicApi ports from docker-compose.yml port mappings instead of returning :0.