### PR TITLE
fix: preserve execa escalation after group kill

### DIFF
--- a/src/lib/process-runner.test.ts
+++ b/src/lib/process-runner.test.ts
@@ -231,6 +231,7 @@ describe('createProcessRunner', () => {
     await expect(proc.waitForExit()).resolves.toBe(0)
     expect(onExit).toHaveBeenCalledWith(0)
     expect(processKill).toHaveBeenCalledWith(-4242, 'SIGINT')
+    expect((execa.mock.results[0]?.value as {kill: ReturnType<typeof vi.fn>}).kill).toHaveBeenCalledWith('SIGINT')
     expect(proc.pid).toBe(4242)
     expect(proc.stdout).toEqual({label: 'stdout'})
     expect(proc.stderr).toEqual({label: 'stderr'})
@@ -265,6 +266,7 @@ describe('createProcessRunner', () => {
 
     await expect(proc.waitForExit()).resolves.toBeNull()
     expect(processKill).toHaveBeenCalledWith(-4242, 'SIGTERM')
+    expect((execa.mock.results[0]?.value as {kill: ReturnType<typeof vi.fn>}).kill).toHaveBeenCalledWith('SIGTERM')
   })
 
   it('falls back to direct child kill when process-group signaling fails', async () => {

--- a/src/lib/process-runner.ts
+++ b/src/lib/process-runner.ts
@@ -250,7 +250,6 @@ export function createProcessRunner(deps: ProcessRunnerDeps = {}): ProcessRunner
           if (supportsProcessGroups && typeof proc.pid === 'number') {
             try {
               processKill(-proc.pid, signal)
-              return
             } catch {
               // Fall through to direct child kill when process-group signaling fails.
             }


### PR DESCRIPTION
## Summary
- keep the POSIX process-group signal for spawned sandbox wrappers
- still call Execa's child `kill()` path so `forceKillAfterDelay` remains active
- extend the process-runner tests to assert both the group signal and the direct child kill happen

## Why
PR #12 fixed orphaned `dpm sandbox` JVMs by signaling the spawned process group, but that change accidentally bypassed Execa's built-in escalation path. This follow-up preserves both behaviors.

## Validation
- `npm run build`
- `npx vitest run --project unit src/lib/process-runner.test.ts`
- `CI=1 npx vitest run --project e2e-sandbox test/e2e/dev.e2e.test.ts`
